### PR TITLE
Specify library dependencies in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -8,3 +8,4 @@ category=Sensors
 url=https://github.com/CieNTi/arduino-IoTesla-client
 architectures=esp8266
 includes=IoTesla-client.h
+depends=PubSubClient, SparkFun BME280, MPU6050


### PR DESCRIPTION
Specifying the library dependencies in the `depends` field of library.properties causes the Arduino Library Manager (Arduino IDE 1.8.10 and newer) to offer to install any missing dependencies during installation of this library.

`arduino-cli lib install` will automatically install the dependencies (arduino-cli 0.7.0 and newer).

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format

Note that I did not add the MQTT library as a dependency. I omitted this because it is not required in the default configuration of the library. However, I think a reasonable argument could be made that it's worth installing all the possible dependencies of the library, since it's really not such a big deal to install a library that's not needed. If you prefer that I add the MQTT library to the dependencies list, I'm happy to do so. Just let me know.